### PR TITLE
Implement Codex Rater app

### DIFF
--- a/api/results.ts
+++ b/api/results.ts
@@ -1,0 +1,9 @@
+import { getVoteCounts, calculatePercentages } from "../kv/kv.ts";
+
+export default async function handler(_req: Request): Promise<Response> {
+  const counts = await getVoteCounts();
+  const percentages = calculatePercentages(counts);
+  return new Response(JSON.stringify({ counts, percentages }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/api/vote.ts
+++ b/api/vote.ts
@@ -1,0 +1,21 @@
+import { incrementVote } from "../kv/kv.ts";
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  let data: unknown;
+  try {
+    data = await req.json();
+  } catch {
+    return new Response("Invalid JSON", { status: 400 });
+  }
+  const vote = (data as Record<string, unknown>).vote;
+  if (typeof vote !== "number" || vote < 1 || vote > 5) {
+    return new Response("Invalid vote", { status: 400 });
+  }
+
+  await incrementVote(vote);
+  return new Response("OK", { status: 200 });
+}

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,9 @@
+{
+  "tasks": {
+    "start": "deno run -A main.ts"
+  },
+  "imports": {
+    "serve": "https://deno.land/std@0.203.0/http/server.ts",
+    "serveDir": "https://deno.land/std@0.203.0/http/file_server.ts"
+  }
+}

--- a/kv/kv.ts
+++ b/kv/kv.ts
@@ -1,0 +1,24 @@
+export const kv = await Deno.openKv();
+
+export async function incrementVote(value: number) {
+  const key = ["votes", value];
+  const current = (await kv.get<number>(key)).value ?? 0;
+  await kv.set(key, current + 1);
+}
+
+export async function getVoteCounts(): Promise<Record<number, number>> {
+  const counts: Record<number, number> = {};
+  for (let i = 1; i <= 5; i++) {
+    counts[i] = (await kv.get<number>(["votes", i])).value ?? 0;
+  }
+  return counts;
+}
+
+export function calculatePercentages(counts: Record<number, number>): Record<number, number> {
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+  const result: Record<number, number> = {};
+  for (let i = 1; i <= 5; i++) {
+    result[i] = total > 0 ? Math.round((counts[i] / total) * 100) : 0;
+  }
+  return result;
+}

--- a/main.ts
+++ b/main.ts
@@ -1,0 +1,15 @@
+import { serve } from "serve";
+import { serveDir } from "serveDir";
+import voteHandler from "./api/vote.ts";
+import resultsHandler from "./api/results.ts";
+
+serve((req) => {
+  const url = new URL(req.url);
+  if (url.pathname === "/api/vote") {
+    return voteHandler(req);
+  }
+  if (url.pathname === "/api/results") {
+    return resultsHandler(req);
+  }
+  return serveDir(req, { fsRoot: "./static", urlRoot: "" });
+});

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,48 @@
+const votedKey = 'voted';
+
+async function sendVote(value) {
+  await fetch('/api/vote', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ vote: value })
+  });
+}
+
+async function fetchResults() {
+  const res = await fetch('/api/results');
+  return res.json();
+}
+
+function renderChart(percentages) {
+  const svg = document.getElementById('chart');
+  svg.innerHTML = '';
+  const barWidth = 15;
+  Object.keys(percentages).forEach((key, idx) => {
+    const height = percentages[key];
+    const x = idx * (barWidth + 5);
+    const y = 60 - height * 0.6;
+    const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    rect.setAttribute('x', x);
+    rect.setAttribute('y', y);
+    rect.setAttribute('width', barWidth);
+    rect.setAttribute('height', height * 0.6);
+    rect.setAttribute('class', 'bar');
+    svg.appendChild(rect);
+  });
+}
+
+async function loadResults() {
+  const data = await fetchResults();
+  renderChart(data.percentages);
+}
+
+function handleVoteClick(e) {
+  const value = Number(e.currentTarget.dataset.vote);
+  if (localStorage.getItem(votedKey)) return;
+  sendVote(value).then(loadResults);
+  localStorage.setItem(votedKey, '1');
+}
+
+document.querySelectorAll('.vote').forEach(btn => btn.addEventListener('click', handleVoteClick));
+
+loadResults();

--- a/static/icons/1.svg
+++ b/static/icons/1.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
+  <circle cx='50' cy='50' r='40' fill='#ccc'/>
+  <text x='50' y='55' font-size='40' text-anchor='middle' fill='black'>1</text>
+</svg>

--- a/static/icons/2.svg
+++ b/static/icons/2.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
+  <circle cx='50' cy='50' r='40' fill='#ccc'/>
+  <text x='50' y='55' font-size='40' text-anchor='middle' fill='black'>2</text>
+</svg>

--- a/static/icons/3.svg
+++ b/static/icons/3.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
+  <circle cx='50' cy='50' r='40' fill='#ccc'/>
+  <text x='50' y='55' font-size='40' text-anchor='middle' fill='black'>3</text>
+</svg>

--- a/static/icons/4.svg
+++ b/static/icons/4.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
+  <circle cx='50' cy='50' r='40' fill='#ccc'/>
+  <text x='50' y='55' font-size='40' text-anchor='middle' fill='black'>4</text>
+</svg>

--- a/static/icons/5.svg
+++ b/static/icons/5.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
+  <circle cx='50' cy='50' r='40' fill='#ccc'/>
+  <text x='50' y='55' font-size='40' text-anchor='middle' fill='black'>5</text>
+</svg>

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Codex Rater</title>
+  <script src="https://cdn.tailwindcss.com?plugins=@tailwindcss/container-queries"></script>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="min-h-screen flex flex-col items-center justify-center p-4">
+  <h1 class="text-2xl mb-4">Rate the Codex Talk!</h1>
+  <div id="icons" class="flex gap-2 mb-6">
+    <button data-vote="1" class="vote"><img src="icons/1.svg" alt="1" /></button>
+    <button data-vote="2" class="vote"><img src="icons/2.svg" alt="2" /></button>
+    <button data-vote="3" class="vote"><img src="icons/3.svg" alt="3" /></button>
+    <button data-vote="4" class="vote"><img src="icons/4.svg" alt="4" /></button>
+    <button data-vote="5" class="vote"><img src="icons/5.svg" alt="5" /></button>
+  </div>
+  <div class="w-full max-w-md">
+    <svg id="chart" viewBox="0 0 100 60" class="w-full"></svg>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,11 @@
+@layer utilities {
+  .bar {
+    fill: theme('colors.blue.500');
+  }
+}
+
+@container (max-width: 400px) {
+  #icons {
+    flex-direction: column;
+  }
+}

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+import voteHandler from "../api/vote.ts";
+import resultsHandler from "../api/results.ts";
+import { kv } from "../kv/kv.ts";
+
+Deno.test("vote endpoint", async () => {
+  await kv.delete(["votes", 2]);
+  const req = new Request("http://localhost/api/vote", {
+    method: "POST",
+    body: JSON.stringify({ vote: 2 }),
+    headers: { "Content-Type": "application/json" },
+  });
+  const res = await voteHandler(req);
+  assertEquals(res.status, 200);
+  const counts = await kv.get<number>(["votes", 2]);
+  assertEquals(counts.value, 1);
+});
+
+Deno.test("results endpoint", async () => {
+  const req = new Request("http://localhost/api/results");
+  const res = await resultsHandler(req);
+  const data = await res.json();
+  assertEquals(typeof data.counts, "object");
+  assertEquals(typeof data.percentages, "object");
+});

--- a/tests/kv.test.ts
+++ b/tests/kv.test.ts
@@ -1,0 +1,16 @@
+import { assertEquals } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+import { kv, incrementVote, getVoteCounts, calculatePercentages } from "../kv/kv.ts";
+
+Deno.test("increment and get counts", async () => {
+  await kv.delete(["votes", 1]);
+  await incrementVote(1);
+  const counts = await getVoteCounts();
+  assertEquals(counts[1], 1);
+});
+
+Deno.test("calculate percentages", () => {
+  const counts = { 1: 1, 2: 1, 3: 0, 4: 0, 5: 0 } as Record<number, number>;
+  const perc = calculatePercentages(counts);
+  assertEquals(perc[1], 50);
+  assertEquals(perc[2], 50);
+});


### PR DESCRIPTION
## Summary
- build minimal Deno server with `/api` routes and static files
- use Deno KV for vote storage and percentage calculations
- add vanilla JS frontend that posts votes and renders an SVG chart
- include Tailwind styles with container query example
- provide basic tests for KV logic and API handlers

## Testing
- `deno test` *(fails: `deno` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd861f6b8832e929c1aea7302f0b0